### PR TITLE
Forward more information to WolframAlpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ For deeper exploration, you can also request the sources behind the answer.
 An email will be sent to your registered account linking you to all the
 details within Wolfram Alpha's website.
 
+## Configuration
+
+Add a block to your `~/.mycroft/mycroft.conf` file like this:
+
+```
+  "WolframAlphaSkill": {
+    "api_key": "yoursuperscretetAppID",
+    # to make use of your api key turn proxy off
+    "proxy": true, 
+    # Turn on to improve answers based on current location
+    "forward_location": false
+  }
+```
+
 ## Examples 
 * "How tall is Mount Everest?"
 * "When was The Rocky Horror Picture Show released?"

--- a/README.md
+++ b/README.md
@@ -10,20 +10,6 @@ For deeper exploration, you can also request the sources behind the answer.
 An email will be sent to your registered account linking you to all the
 details within Wolfram Alpha's website.
 
-## Configuration
-
-Add a block to your `~/.mycroft/mycroft.conf` file like this:
-
-```
-  "WolframAlphaSkill": {
-    "api_key": "yoursuperscretetAppID",
-    # to make use of your api key turn proxy off
-    "proxy": true, 
-    # Turn on to improve answers based on current location
-    "forward_location": false
-  }
-```
-
 ## Examples 
 * "How tall is Mount Everest?"
 * "When was The Rocky Horror Picture Show released?"

--- a/__init__.py
+++ b/__init__.py
@@ -75,8 +75,8 @@ class WAApi(Api):
     def get_data(self, response):
         return response
 
-    def query(self, input):
-        data = self.request({"query": {"input": input}})
+    def query(self, input, params=()):
+        data = self.request({"query": {"input": input, "params": params}})
         return wolframalpha.Result(StringIO(data.content))
 
 
@@ -102,9 +102,11 @@ class WolframAlphaSkill(FallbackSkill):
 
         if appID and not self.config.get('proxy'):
             # user has a private AppID
+            self.log.debug("Creating a private client")
             self.client = wolframalpha.Client(appID)
         else:
             # use the default API for Wolfram queries
+            self.log.debug("Using the default API")
             self.client = WAApi()
 
     def initialize(self):
@@ -148,8 +150,9 @@ class WolframAlphaSkill(FallbackSkill):
             # Try to store pieces of utterance (None if not parsed_question)
             utt_word = parsed_question.get('QuestionWord')
             utt_verb = parsed_question.get('QuestionVerb')
-            utt_query = parsed_question.get('Query')
-            query = "%s %s %s" % (utt_word, utt_verb, utt_query)
+            utt_query = parsed_question.get('Query')        
+            
+            query = "%s %s %s" % (utt_word, utt_verb, utt_query)           
             phrase = "know %s %s %s" % (utt_word, utt_query, utt_verb)
             self.log.debug("Querying WolframAlpha: " + query)
         else:
@@ -159,8 +162,41 @@ class WolframAlphaSkill(FallbackSkill):
             return False
 
         try:
+            # Make several assumptions based on the user settings
+            params = ()
+            
+            # TODO ask user if he/she wants location forwarded => settings
+            if self.config.get("forward_location"):
+            
+                latlong = self.config_core.get('location')['coordinate']
+                params += (
+                    ('latlong', str(latlong['latitude'])+ "," + str(latlong['longitude'])),
+                )
+            
+            # Based on the setting for the date format, assume certain things
+            if self.config_core.get('date_format') == 'MDY':
+                params += (('assumption', 'DateOrder_**Month.Day.Year--'),)
+            else:
+                params += (('assumption', 'DateOrder_**Day.Month.Year--'),)
+            
+            # line to get the current settings for preferred units
+            # can be metric or imperial
+            # => ask wolfram alpha to convert the output 
+            #    to the preferred unit system
+            # based on self.config_core.get('system_unit')
+            if self.config_core.get('system_unit') == 'imperial':
+                params += (
+                    ('units', 'nonmetric'),
+                )
+            else:
+                params += (
+                    ('units', 'metric'),
+                )
+        
             self.enclosure.mouth_think()
-            res = self.client.query(query)
+            # Params thus get ignored if  using the official API (by now)
+            # but should be considered when delivering an appId
+            res = self.client.query(query, params)
             result = self.get_result(res)
         except HTTPError as e:
             if e.response.status_code == 401:

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -1,0 +1,31 @@
+{
+  "identifier": "WolframAlphaSkill",
+  "name": "WolframAlpha",
+  "skillMetadata": {
+      "sections": [
+          {
+              "name": "Login",
+              "fields": [
+                  {
+                      "name": "api_key",
+                      "type": "text",
+                      "label": "own appID",
+                      "value": ""
+                  },
+                  {
+                      "name": "proxy",
+                      "type": "bool",
+                      "label": "Use mycroft proxy instead of own appID",
+                      "value": "true"
+                  },
+                  {
+                      "name": "forward_location",
+                      "type": "bool",
+                      "label": "forward location to WolframAlpha",
+                      "value": "false"
+                  }
+              ]
+          }
+      ]
+  }
+}

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -14,13 +14,13 @@
                   },
                   {
                       "name": "proxy",
-                      "type": "bool",
+                      "type": "checkbox",
                       "label": "Use mycroft proxy instead of own appID",
                       "value": "true"
                   },
                   {
                       "name": "forward_location",
-                      "type": "bool",
+                      "type": "checkbox",
                       "label": "forward location to WolframAlpha",
                       "value": "false"
                   }


### PR DESCRIPTION
The user now has the choice to provide additional data to the wolframalpha knowledge engine.
This feature only works if either the official Mycroft api gets updated or the user provides his own appID.

Given the official api gets upgraded or you enter an api_key in the config file wolframalpha now receives plenty of additional data.
[Assumptions](https://products.wolframalpha.com/api/documentation/#assumption-DateOrder) based on your settings for date formats
[Location](https://products.wolframalpha.com/api/documentation/#specifying-your-location) based on your settings in home.mycroft, given you add the key 'forward_location' : true to the configuration
[Automatic unit conversion](https://products.wolframalpha.com/api/documentation/#top) based on your preferences in home.mycroft
  