### PR TITLE
Remove "others"

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -180,13 +180,7 @@ class WolframAlphaSkill(FallbackSkill):
             self.speak(response)
             return True
         else:
-            if len(others) > 0:
-                self.speak_dialog('others.found',
-                                  data={'utterance': utterance,
-                                        'alternative': others[0]})
-                return True
-            else:
-                return False
+            return False
 
     @staticmethod
     def __find_pod_id(pods, pod_id):

--- a/dialog/en-us/others.found.dialog
+++ b/dialog/en-us/others.found.dialog
@@ -1,2 +1,0 @@
-Sorry, I couldn't find an answer for {{utterance}}. Perhaps you meant {{alternative}} instead?
-I couldn't get a response for {{utterance}}. Maybe you meant {{alternative}}?


### PR DESCRIPTION
A leftover from previous versions causes errors at times when the
fallback can't handle the utterance.