### PR TITLE
Python 3 compatibility

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from StringIO import StringIO
+try:
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO
 
 import re
 import wolframalpha


### PR DESCRIPTION
This changes the import to be Python 3 compatible with a fallback to Python 2's import.