### PR TITLE
Adding a event listener to respond with text without speaking

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -150,7 +150,7 @@ class WolframAlphaSkill(CommonQuerySkill):
     def initialize(self):
         self._setup()
         self.settings_change_callback =self.on_settings_changed
-        self.add_event('wolfram.unspoken.request', self.emit_text_result)
+        self.add_event('skill.wolfram.unspoken.request', self.emit_text_result)
 
     def on_settings_changed(self):
         self.log.debug("settings changed")
@@ -182,7 +182,7 @@ class WolframAlphaSkill(CommonQuerySkill):
 
     def emit_text_result(self, message):
         response = self.client.query_to_string(message.data.get('query'))
-        self.bus.emit(Message("wolfram.unspoken.response", {'result': response}))
+        self.bus.emit(Message("skill.wolfram.unspoken.response", {'result': response}))
 
     def CQS_match_query_phrase(self, utt):
         self.log.debug("WolframAlpha query: " + utt)


### PR DESCRIPTION
I was wanting to use information from WolframAlpha in another skill without mycroft speaking the results so I added a listener for `wolfram.unspoken.request` messages which triggers the `emit_text_result` method and a `wolfram.unspoken.response` message is then sent with the result.

I had to add the `query_to_string` method because the `query` method kept failing because `wolfram.Result()` did not like the output of 'BytesIO(data.content)`.

This is my first time contributing, and I was a little unsure of how the `Api` inheritance was working so I would love some feedback on how it can be improved. 