### PR TITLE
Remove usage of "emitter"

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -229,7 +229,7 @@ class WolframAlphaSkill(CommonQuerySkill):
                 return None
         except HTTPError as e:
             if e.response.status_code == 401:
-                self.emitter.emit(Message("mycroft.not.paired"))
+                self.bus.emit(Message("mycroft.not.paired"))
             return True
         except Exception as e:
             self.log.exception(e)


### PR DESCRIPTION
#### Description
self.emitter was still used to try to call pairing, this seems to have been missed when switching from using `self.emitter` to
`self.bus`.

The code is rarely used but should trigger pairing if wolfram alpha is called when unpaired and wolfram response can't be fetched through Mycroft Home. Possibly the functionality should be removed?

This also fixes an incorrect return value after that showed up when the main issue was resolved.

#### Type of PR
- [ x ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Run the skill in an unpaired state and enter a question on the CLI, an error message should not be seen in the log.